### PR TITLE
Implicitly marking parameter (variable) as nullable is deprecated

### DIFF
--- a/Api/Data/CouponCollectionInterface.php
+++ b/Api/Data/CouponCollectionInterface.php
@@ -20,5 +20,5 @@ interface CouponCollectionInterface
      * @param \Remarkety\Mgconnector\Api\Data\CouponInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(?array $items = null);
 }

--- a/Api/Data/CustomerCollectionInterface.php
+++ b/Api/Data/CustomerCollectionInterface.php
@@ -20,5 +20,5 @@ interface CustomerCollectionInterface
      * @param \Remarkety\Mgconnector\Api\Data\CustomerInterface[] $items
      * @return $this
      */
-    public function setCustomers(array $items = null);
+    public function setCustomers(?array $items = null);
 }

--- a/Api/Data/OrderCollectionInterface.php
+++ b/Api/Data/OrderCollectionInterface.php
@@ -20,5 +20,5 @@ interface OrderCollectionInterface
      * @param \Remarkety\Mgconnector\Api\Data\OrderInterface[] $items
      * @return $this
      */
-    public function setOrders(array $items = null);
+    public function setOrders(?array $items = null);
 }

--- a/Api/Data/QueueCollectionInterface.php
+++ b/Api/Data/QueueCollectionInterface.php
@@ -20,5 +20,5 @@ interface QueueCollectionInterface
      * @param \Remarkety\Mgconnector\Api\Data\QueueInterface[] $items
      * @return $this
      */
-    public function setQueueItems(array $items = null);
+    public function setQueueItems(?array $items = null);
 }

--- a/Api/Data/QuoteCollectionInterface.php
+++ b/Api/Data/QuoteCollectionInterface.php
@@ -20,5 +20,5 @@ interface QuoteCollectionInterface
      * @param \Remarkety\Mgconnector\Api\Data\QuoteInterface[] $items
      * @return $this
      */
-    public function setCarts(array $items = null);
+    public function setCarts(?array $items = null);
 }

--- a/Api/Data/StoreOrderStatusesCollectionInterface.php
+++ b/Api/Data/StoreOrderStatusesCollectionInterface.php
@@ -20,5 +20,5 @@ interface StoreOrderStatusesCollectionInterface
      * @param \Remarkety\Mgconnector\Api\Data\StoreOrderStatusesInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(?array $items = null);
 }

--- a/Api/Data/StoreSettingsCollectionInterface.php
+++ b/Api/Data/StoreSettingsCollectionInterface.php
@@ -20,5 +20,5 @@ interface StoreSettingsCollectionInterface
      * @param \Remarkety\Mgconnector\Api\Data\StoreSettingsInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(?array $items = null);
 }

--- a/Model/Api/Data/CouponCollection.php
+++ b/Model/Api/Data/CouponCollection.php
@@ -9,7 +9,7 @@ class CouponCollection implements \Remarkety\Mgconnector\Api\Data\CouponCollecti
         return $this->_items;
     }
 
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         $this->_items = $items;
     }

--- a/Model/Api/Data/CustomerCollection.php
+++ b/Model/Api/Data/CustomerCollection.php
@@ -9,7 +9,7 @@ class CustomerCollection implements \Remarkety\Mgconnector\Api\Data\CustomerColl
         return $this->_items;
     }
 
-    public function setCustomers(array $items = null)
+    public function setCustomers(?array $items = null)
     {
         $this->_items = $items;
     }

--- a/Model/Api/Data/OrderCollection.php
+++ b/Model/Api/Data/OrderCollection.php
@@ -9,7 +9,7 @@ class OrderCollection implements \Remarkety\Mgconnector\Api\Data\OrderCollection
         return $this->_items;
     }
 
-    public function setOrders(array $items = null)
+    public function setOrders(?array $items = null)
     {
         $this->_items = $items;
     }

--- a/Model/Api/Data/QueueCollection.php
+++ b/Model/Api/Data/QueueCollection.php
@@ -9,7 +9,7 @@ class QueueCollection implements \Remarkety\Mgconnector\Api\Data\QueueCollection
         return $this->_items;
     }
 
-    public function setQueueItems(array $items = null)
+    public function setQueueItems(?array $items = null)
     {
         $this->_items = $items;
     }

--- a/Model/Api/Data/QuoteCollection.php
+++ b/Model/Api/Data/QuoteCollection.php
@@ -9,7 +9,7 @@ class QuoteCollection implements \Remarkety\Mgconnector\Api\Data\QuoteCollection
         return $this->_items;
     }
 
-    public function setCarts(array $items = null)
+    public function setCarts(?array $items = null)
     {
         $this->_items = $items;
     }

--- a/Model/Api/Data/StoreOrderStatusesCollection.php
+++ b/Model/Api/Data/StoreOrderStatusesCollection.php
@@ -9,7 +9,7 @@ class StoreOrderStatusesCollection implements \Remarkety\Mgconnector\Api\Data\St
         return $this->_items;
     }
 
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         $this->_items = $items;
     }

--- a/Model/Api/Data/StoreSettingsCollection.php
+++ b/Model/Api/Data/StoreSettingsCollection.php
@@ -9,7 +9,7 @@ class StoreSettingsCollection implements \Remarkety\Mgconnector\Api\Data\StoreSe
         return $this->_items;
     }
 
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         $this->_items = $items;
     }

--- a/Serializer/CustomerSerializer.php
+++ b/Serializer/CustomerSerializer.php
@@ -35,10 +35,10 @@ class CustomerSerializer
         AddressSerializer $addressSerializer,
         CustomerGroupRepository $customerGroupRepository,
         RequestInterface $request,
-        ?LoggerInterface $logger = null,
         ConfigHelper $configHelper,
         DataOverride $dataOverride,
-        Data $dataHelper
+        Data $dataHelper,
+        ?LoggerInterface $logger = null,
     ) {
         $this->subscriber = $subscriber;
         $this->addressSerializer = $addressSerializer;

--- a/Serializer/CustomerSerializer.php
+++ b/Serializer/CustomerSerializer.php
@@ -15,7 +15,7 @@ use Magento\Customer\Api\GroupRepositoryInterface as CustomerGroupRepository;
 use Remarkety\Mgconnector\Helper\ConfigHelper;
 use Remarkety\Mgconnector\Helper\Data;
 use Remarkety\Mgconnector\Helper\DataOverride;
-
+use Psr\Log\LoggerInterface
 class CustomerSerializer
 {
     use CheckSubscriberTrait;
@@ -34,7 +34,7 @@ class CustomerSerializer
         AddressSerializer $addressSerializer,
         CustomerGroupRepository $customerGroupRepository,
         RequestInterface $request,
-        \Psr\Log\LoggerInterface $logger = null,
+        ?LoggerInterface $logger = null,
         ConfigHelper $configHelper,
         DataOverride $dataOverride,
         Data $dataHelper

--- a/Serializer/CustomerSerializer.php
+++ b/Serializer/CustomerSerializer.php
@@ -15,7 +15,8 @@ use Magento\Customer\Api\GroupRepositoryInterface as CustomerGroupRepository;
 use Remarkety\Mgconnector\Helper\ConfigHelper;
 use Remarkety\Mgconnector\Helper\Data;
 use Remarkety\Mgconnector\Helper\DataOverride;
-use Psr\Log\LoggerInterface
+use Psr\Log\LoggerInterface;
+
 class CustomerSerializer
 {
     use CheckSubscriberTrait;


### PR DESCRIPTION
It would not work on php 8.3 without this PR